### PR TITLE
fix/CommonNameSpace

### DIFF
--- a/DemoApp/DemoApp/Views/TMCardPage.xaml
+++ b/DemoApp/DemoApp/Views/TMCardPage.xaml
@@ -2,8 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:constants="clr-namespace:DemoApp.Constant"
-             xmlns:Modus="clr-namespace:Trimble.Modus.Components.Controls.TMCard;assembly=Trimble.Modus.Components"
-             xmlns:local="clr-namespace:Trimble.Modus.Components;assembly=Trimble.Modus.Components"
+             xmlns:Modus="clr-namespace:Trimble.Modus.Components;assembly=Trimble.Modus.Components"
              x:Class="DemoApp.Views.TMCardPage"
              Title="TMCardPage">
   <ScrollView>
@@ -92,7 +91,7 @@
           <StackLayout BackgroundColor="Transparent"
                        HorizontalOptions="End"
                        Padding="0,10,0,10">
-            <local:TMButton Title="Button"></local:TMButton>
+            <Modus:TMButton Title="Button"></Modus:TMButton>
           </StackLayout>
         </StackLayout>
       </Modus:TMCard>
@@ -125,7 +124,7 @@
           <!-- Footer -->
           <StackLayout BackgroundColor="Transparent"
                        Padding="0,10,0,10">
-            <local:TMButton Title="Button"
+            <Modus:TMButton Title="Button"
                     HorizontalOptions="FillAndExpand" />
           </StackLayout>
         </StackLayout>
@@ -174,11 +173,11 @@
           <StackLayout BackgroundColor="Transparent"
                        Orientation="Horizontal"
                        Spacing="15">
-            <local:TMButton Title="Button"
+            <Modus:TMButton Title="Button"
                             ButtonStyle="Outline">
-            </local:TMButton>
-            <local:TMButton Title="Button"
-                            ButtonStyle="Fill"></local:TMButton>
+            </Modus:TMButton>
+            <Modus:TMButton Title="Button"
+                            ButtonStyle="Fill"></Modus:TMButton>
 
           </StackLayout>
         </StackLayout>

--- a/DemoApp/DemoApp/Views/TMCardPage.xaml.cs
+++ b/DemoApp/DemoApp/Views/TMCardPage.xaml.cs
@@ -1,6 +1,6 @@
 using System.Reflection.Metadata;
 using System.Windows.Input;
-using Trimble.Modus.Components.Controls.TMCard;
+using Trimble.Modus.Components;
 
 namespace DemoApp.Views;
 

--- a/DemoApp/DemoApp/Views/TMModalPage.xaml.cs
+++ b/DemoApp/DemoApp/Views/TMModalPage.xaml.cs
@@ -1,6 +1,5 @@
 using DemoApp.Constant;
 using Trimble.Modus.Components;
-using Trimble.Modus.Components.Controls.Toast;
 using Trimble.Modus.Components.Enums;
 
 namespace DemoApp.Views;

--- a/DemoApp/DemoApp/Views/TMToastPage.xaml.cs
+++ b/DemoApp/DemoApp/Views/TMToastPage.xaml.cs
@@ -1,4 +1,4 @@
-using Trimble.Modus.Components.Controls.Toast;
+using Trimble.Modus.Components;
 using Trimble.Modus.Components.Enums;
 
 namespace DemoApp;

--- a/Trimble.Modus.Components/Controls/TMCard/TMCard.xaml.cs
+++ b/Trimble.Modus.Components/Controls/TMCard/TMCard.xaml.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 using Trimble.Modus.Components.Constant;
 using Trimble.Modus.Components.Helpers;
 
-namespace Trimble.Modus.Components.Controls.TMCard;
+namespace Trimble.Modus.Components;
 
 public partial class TMCard : ContentView
 {

--- a/Trimble.Modus.Components/Controls/Toast/TMToast.cs
+++ b/Trimble.Modus.Components/Controls/Toast/TMToast.cs
@@ -1,7 +1,8 @@
-﻿using Trimble.Modus.Components.Enums;
+﻿using Trimble.Modus.Components.Controls.Toast;
+using Trimble.Modus.Components.Enums;
 using Trimble.Modus.Components.Popup.Services;
 
-namespace Trimble.Modus.Components.Controls.Toast
+namespace Trimble.Modus.Components
 {
     public class TMToast
     {


### PR DESCRIPTION
Moved every control to common namespace(Trimble.Modus.Components).