### PR TITLE
Disable label handler mapping for windows

### DIFF
--- a/Trimble.Modus.Components/Handlers/LabelHandler.cs
+++ b/Trimble.Modus.Components/Handlers/LabelHandler.cs
@@ -4,7 +4,7 @@ internal partial class LabelHandler : Microsoft.Maui.Handlers.LabelHandler
 {
     public LabelHandler()
     {
-#if WINDOWS
+#if !WINDOWS
         Label.ControlsLabelMapper.AppendToMapping(
           nameof(Label.LineBreakMode), UpdateMaxLines);
 

--- a/Trimble.Modus.Components/Handlers/LabelHandler.cs
+++ b/Trimble.Modus.Components/Handlers/LabelHandler.cs
@@ -4,11 +4,13 @@ internal partial class LabelHandler : Microsoft.Maui.Handlers.LabelHandler
 {
     public LabelHandler()
     {
+#if WINDOWS
         Label.ControlsLabelMapper.AppendToMapping(
           nameof(Label.LineBreakMode), UpdateMaxLines);
 
         Label.ControlsLabelMapper.AppendToMapping(
           nameof(Label.MaxLines), UpdateMaxLines);
+#endif
     }
     static void UpdateMaxLines(Microsoft.Maui.Handlers.LabelHandler handler, ILabel label)
     {


### PR DESCRIPTION
Disable label handler mapping for windows as it is causing an exception as its causing an exception in Windows