### PR TITLE
Fix/344 listview selected item highlighting

### DIFF
--- a/DemoApp/DemoApp/Platforms/Windows/App.xaml
+++ b/DemoApp/DemoApp/Platforms/Windows/App.xaml
@@ -5,6 +5,9 @@
     xmlns:maui="using:Microsoft.Maui"
     xmlns:local="using:DemoApp.WinUI">
     <maui:MauiWinUIApplication.Resources>
+        <StaticResource x:Key="ListViewItemBackgroundSelectedPointerOver" ResourceKey="ListViewItemBackgroundColor" />
+        <StaticResource x:Key="ListViewItemBackgroundSelected" ResourceKey="ListViewItemBackgroundColor" />
+        <SolidColorBrush x:Key="ListViewItemBackgroundColor"  Color="#DCEDF9" />
         <Thickness x:Key="TextControlBorderThemeThickness">0</Thickness>
         <Thickness x:Key="TextControlBorderThemeThicknessFocused">0</Thickness>
     </maui:MauiWinUIApplication.Resources>

--- a/Trimble.Modus.Components/Controls/DropDown/TMDropDown.xaml.cs
+++ b/Trimble.Modus.Components/Controls/DropDown/TMDropDown.xaml.cs
@@ -80,8 +80,7 @@ public partial class TMDropDown : ContentView
         InitializeComponent();
         var tapGestureRecognizer = new TapGestureRecognizer();
         tapGestureRecognizer.Tapped += OnTapped;
-        ContentLayout.GestureRecognizers.Add(tapGestureRecognizer);
-        indicatorButton.GestureRecognizers.Add(tapGestureRecognizer);
+        innerBorder.GestureRecognizers.Add(tapGestureRecognizer);
         PopupService.Instance.Dismissed += OnPopupRemoved;
         //Content = innerBorder;
     }

--- a/Trimble.Modus.Components/Controls/ListView/TMListView.xaml.cs
+++ b/Trimble.Modus.Components/Controls/ListView/TMListView.xaml.cs
@@ -52,7 +52,7 @@ public partial class TMListView : ListView
     {
         HasUnevenRows = true;
         ItemTapped += ListViewItemTapped;
-        (this as ListView)?.SetValue(ListView.SelectionModeProperty, ListViewSelectionMode.None);  
+        (this as ListView)?.SetValue(ListView.SelectionModeProperty, ListViewSelectionMode.Single);  
         SelectableItems = new List<object> { };
     }
     #endregion


### PR DESCRIPTION
Fixed - listview selected item not highlighting for windows - 344. 
In demo app as well it was not working. 
Fix -Changed Listview selection to Single from None
![image](https://github.com/trimble-oss/modus-mobile-maui-components/assets/152365271/0fd9a7fa-a0d1-4157-89e0-db28d850dddb)
Added the windows platform code to highlight the backgroundcolor for selected item
![image](https://github.com/trimble-oss/modus-mobile-maui-components/assets/152365271/d307e185-baec-4bff-9071-db1b11259a67)
This above code should be added from the user end

Fixed - Dropdown popup is not opening when we click around the text - 355
The dropdown popup opening only when click a text or icon. when i click around the text the popup will not open
![image](https://github.com/trimble-oss/modus-mobile-maui-components/assets/152365271/d5b7a9d1-4880-49e7-8de1-a07677e916fa)

Fix - Added the Gesture for innerborder component. Since innerborder gesture is enough for dropdown, when dropdown view the popup will open. Removed gesture for ContentLayout and indicatorButton
![image](https://github.com/trimble-oss/modus-mobile-maui-components/assets/152365271/7843f85c-382f-48fa-a3b5-0e14a5cb71ab)

