### PR TITLE
342 button text alignment issue

### DIFF
--- a/Trimble.Modus.Components/Controls/Button/TMButton.xaml
+++ b/Trimble.Modus.Components/Controls/Button/TMButton.xaml
@@ -22,10 +22,10 @@
           StrokeShape="RoundRectangle 4,4">
     <StackLayout x:Name="buttonStackLayout"
                  Orientation="Horizontal"
-                 HorizontalOptions="Center"
+                 HorizontalOptions="Fill"
                  VerticalOptions="Center"
                  Padding="0,8">
-      <StackLayout HorizontalOptions="Fill"
+      <StackLayout HorizontalOptions="CenterAndExpand"
                    VerticalOptions="Center"
                    Spacing="8"
                    Orientation="Horizontal">


### PR DESCRIPTION
This button text alignment issue only occurs for Groundworks windows app alone. Groundworks android is working fine. Demo app also works fine. I have made simple fix to work in Groundworks windows app as well. Now all apps are working file.

Please refer this ticket https://github.com/trimble-oss/modus-mobile-maui-components/issues/342