### PR TITLE
Dropdown UI issue #351

### DIFF
--- a/DemoApp/DemoApp/Views/PopupSamples/SampleCustomPopup.xaml
+++ b/DemoApp/DemoApp/Views/PopupSamples/SampleCustomPopup.xaml
@@ -13,14 +13,15 @@
       <modus:TextCell Title="{Binding .}" />
     </DataTemplate>
   </ContentPage.Resources>
-  <Border Padding="16"
+  <Border 
           Margin="20"
           HeightRequest="300">
     <Border.StrokeShape>
       <RoundRectangle CornerRadius="30" />
     </Border.StrokeShape>
     <ScrollView>
-      <VerticalStackLayout>
+      <VerticalStackLayout Padding="16">
+        <modus:TMDropDown ItemsSource="{Binding UpcomingControls}"/>
         <Label Text="Upcoming Controls"
                FontSize="22"
                FontAttributes="Bold"

--- a/Trimble.Modus.Components/Controls/DropDown/DropDownContents.xaml.cs
+++ b/Trimble.Modus.Components/Controls/DropDown/DropDownContents.xaml.cs
@@ -33,8 +33,8 @@ public partial class DropDownContents : PopupPage
         border.HeightRequest = DesiredHeight;
         border.WidthRequest = WidthRequest;
         listView.ItemsSource = ItemSource;
-        listView.ItemSelected += SelectedEventHandler;
         listView.SelectedItem = ItemSource?.Cast<object>()?.ToList()[SelectedIndex];
+        listView.ItemSelected += SelectedEventHandler;        
         if (Height - YPosition < DesiredHeight)
         {
             this.Position = Enums.ModalPosition.Top;


### PR DESCRIPTION
When we click a dropdown, onselected method is triggering. It should trigger only when we click items from the dropdown popup. When we click a dropdown it should open only the dropdown popup, it should not trigger on selected method. 

Because of this only we were getting this dropdown UI issue.
Fix - Just initialized the selected event after setting the selecteditem 

Please check this to know about the issue - https://github.com/trimble-oss/modus-mobile-maui-components/issues/351