### PR TITLE
Changes for Primary key not found exception.

### DIFF
--- a/Trimble.Modus.Components/Controls/DropDown/DropDownContents.xaml.cs
+++ b/Trimble.Modus.Components/Controls/DropDown/DropDownContents.xaml.cs
@@ -1,7 +1,4 @@
-using CommunityToolkit.Mvvm.DependencyInjection;
-using System;
 using System.Collections;
-using Trimble.Modus.Components.Enums;
 using Trimble.Modus.Components.Popup.Animations;
 
 namespace Trimble.Modus.Components;
@@ -13,8 +10,8 @@ public partial class DropDownContents : PopupPage
 
     }
 
-    internal DropDownContents(View anchorView,Enums.ModalPosition position): base(anchorView, position)
-	{
+    internal DropDownContents(View anchorView, Enums.ModalPosition position) : base(anchorView, position)
+    {
         InitializeComponent();
     }
 
@@ -33,8 +30,15 @@ public partial class DropDownContents : PopupPage
         border.HeightRequest = DesiredHeight;
         border.WidthRequest = WidthRequest;
         listView.ItemsSource = ItemSource;
-        listView.SelectedItem = ItemSource?.Cast<object>()?.ToList()[SelectedIndex];
-        listView.ItemSelected += SelectedEventHandler;        
+        if (SelectedIndex < 0)
+        {
+            listView.SelectedItem = null;
+        }
+        else
+        {
+            listView.SelectedItem = ItemSource?.Cast<object>()?.ToList()[SelectedIndex];
+        }
+        listView.ItemSelected += SelectedEventHandler;
         if (Height - YPosition < DesiredHeight)
         {
             this.Position = Enums.ModalPosition.Top;

--- a/Trimble.Modus.Components/Controls/DropDown/DropDownViewCell.cs
+++ b/Trimble.Modus.Components/Controls/DropDown/DropDownViewCell.cs
@@ -1,5 +1,4 @@
 ﻿using Trimble.Modus.Components.Constant;
-using Trimble.Modus.Components.Helpers;
 
 namespace Trimble.Modus.Components;
 
@@ -19,26 +18,27 @@ public class DropDownViewCell : ViewCell
     {
         label = new Label
         {
-            TextColor = ResourcesDictionary.GetColor(ColorsConstants.Secondary),
             FontAttributes = FontAttributes.None,
-            BackgroundColor = ResourcesDictionary.GetColor(ColorsConstants.Transparent),
             VerticalOptions = LayoutOptions.Center,
             HorizontalOptions = LayoutOptions.Start,
             Padding = new Thickness(8, 12)
         };
 
+        label.SetDynamicResource(Label.TextColorProperty, ColorsConstants.Secondary);
+        label.SetDynamicResource(Label.BackgroundColorProperty, ColorsConstants.Transparent);
+
         label.SetBinding(Label.TextProperty, new Binding("Text", source: this));
 
         View = new StackLayout
         {
-            Children = { label
-},
-            BackgroundColor = ResourcesDictionary.GetColor(ColorsConstants.Transparent),
+            Children = { label },
         };
+        View.SetDynamicResource(StackLayout.BackgroundColorProperty, ColorsConstants.Transparent);
     }
-    internal void UpdateBackgroundColor(Color backgroundColor, bool textAttribute)
+
+    internal void UpdateBackgroundColor(string backgroundColorKey, bool textAttribute)
     {
-        View.BackgroundColor = backgroundColor;
+        View.SetDynamicResource(View.BackgroundColorProperty, backgroundColorKey);
         label.FontAttributes = textAttribute ? FontAttributes.Bold : FontAttributes.None;
     }
 }

--- a/Trimble.Modus.Components/Controls/DropDown/TMDropDown.xaml.cs
+++ b/Trimble.Modus.Components/Controls/DropDown/TMDropDown.xaml.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Windows.Input;
 using Trimble.Modus.Components.Constant;
 using Trimble.Modus.Components.Helpers;
-using Trimble.Modus.Components.Popup.Animations;
 using Trimble.Modus.Components.Popup.Services;
 
 namespace Trimble.Modus.Components;
@@ -18,7 +17,7 @@ public partial class TMDropDown : ContentView
     private Thickness margin = new Thickness(0, 154, 0, 0);
 
 #else
-    private Thickness margin = new Thickness(0,128,0,0);
+    private Thickness margin = new Thickness(0, 128, 0, 0);
 #endif
     private uint AnimationDuration { get; set; } = 250;
     private object previousSelection;
@@ -104,7 +103,7 @@ public partial class TMDropDown : ContentView
 
     private void OnTapped(object sender, EventArgs e)
     {
-        Open();        
+        Open();
     }
 
     private async void Close()
@@ -115,7 +114,7 @@ public partial class TMDropDown : ContentView
         );
     }
 
-    
+
     DropDownContents popup;
     private async void Open()
     {
@@ -220,11 +219,11 @@ public partial class TMDropDown : ContentView
             {
                 if (SelectedItem == textCell.BindingContext)
                 {
-                    textCell.UpdateBackgroundColor(ResourcesDictionary.GetColor(ColorsConstants.PrimaryLight), true);
+                    textCell.UpdateBackgroundColor(ColorsConstants.PrimaryLight, true);
                 }
                 else
                 {
-                    textCell.UpdateBackgroundColor(ResourcesDictionary.GetColor(ColorsConstants.AlternateTextColor), false);
+                    textCell.UpdateBackgroundColor(ColorsConstants.AlternateTextColor, false);
                 }
             }
         }

--- a/Trimble.Modus.Components/Controls/TMInput/BaseInput.xaml.cs
+++ b/Trimble.Modus.Components/Controls/TMInput/BaseInput.xaml.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.Maui.Graphics.Text;
-using System.Runtime.CompilerServices;
-using System.Windows.Input;
+﻿using System.Windows.Input;
 using Trimble.Modus.Components.Constant;
 using Trimble.Modus.Components.Enums;
-using Trimble.Modus.Components.Helpers;
 
 namespace Trimble.Modus.Components.Controls.BaseInput;
 
@@ -518,7 +515,7 @@ public partial class BaseInput : ContentView
             {
                 tmInput.InputBorder.Opacity = tmInput.InputLabel.Opacity = tmInput.HelperLayout.Opacity = 1;
                 tmInput.SetDynamicResource(BaseInput.StyleProperty, "Default");
-                tmInput.GetCoreContent().BackgroundColor = ResourcesDictionary.GetColor(ColorsConstants.Transparent);
+                tmInput.GetCoreContent().SetDynamicResource(BackgroundColorProperty, ColorsConstants.Transparent);
                 SetBorderColor(tmInput);
             }
             else

--- a/Trimble.Modus.Components/Controls/TMSlider/SliderCore.cs
+++ b/Trimble.Modus.Components/Controls/TMSlider/SliderCore.cs
@@ -4,7 +4,6 @@ using Trimble.Modus.Components.Constant;
 using Trimble.Modus.Components.Controls.Slider;
 using Trimble.Modus.Components.Controls.TMSlider;
 using Trimble.Modus.Components.Enums;
-using Trimble.Modus.Components.Helpers;
 
 namespace Trimble.Modus.Components.Controls
 {
@@ -313,9 +312,16 @@ namespace Trimble.Modus.Components.Controls
                 {
                     child.Opacity = IsEnabled ? _enabledOpacity : _disabledOpacity;
                 }
-                else if (child is Border)
+                else if (child is Border border)
                 {
-                    (child as Border).Stroke = IsEnabled ? ThumbColor : ResourcesDictionary.GetColor(ColorsConstants.Tertiary);
+                    if (IsEnabled)
+                    {
+                        border.Stroke = ThumbColor;
+                    }
+                    else
+                    {
+                        border.Stroke.SetDynamicResource(Border.StrokeProperty, ColorsConstants.Tertiary);
+                    }
                 }
             }
         }
@@ -329,13 +335,17 @@ namespace Trimble.Modus.Components.Controls
         internal void SetThumbStyle(Border border, double thumbStrokeThickness, double thumbSize)
         {
             border.StrokeThickness = thumbStrokeThickness;
-            border.Stroke = IsEnabled
-                ? ThumbColor
-                : ResourcesDictionary.GetColor(
-                    ColorsConstants.Tertiary
-                );
+            if (IsEnabled)
+            {
+                border.Stroke = ThumbColor;
+            }
+            else
+            {
+                border.SetDynamicResource(Border.StrokeProperty, ColorsConstants.Tertiary);
+            }
+
             border.Margin = new Thickness(0);
-            border.BackgroundColor = ResourcesDictionary.GetColor(ColorsConstants.DefaultTextColor);
+            border.SetDynamicResource(BackgroundColorProperty, ColorsConstants.DefaultTextColor);
             border.StrokeShape = new Ellipse()
             {
                 WidthRequest = thumbSize,
@@ -350,11 +360,14 @@ namespace Trimble.Modus.Components.Controls
         /// <param name="border"></param>
         internal void RefreshThumbColor(Border border)
         {
-            border.Stroke = IsEnabled
-                ? ThumbColor
-                : ResourcesDictionary.GetColor(
-                    ColorsConstants.Tertiary
-                );
+            if (IsEnabled)
+            {
+                border.Stroke = ThumbColor;
+            }
+            else
+            {
+                border.SetDynamicResource(Border.StrokeProperty, ColorsConstants.Tertiary);
+            }
         }
         /// <summary>
         /// Triggered when a thumb is moved

--- a/Trimble.Modus.Components/Controls/TMSlider/SliderHelper.cs
+++ b/Trimble.Modus.Components/Controls/TMSlider/SliderHelper.cs
@@ -1,6 +1,5 @@
 ﻿using Trimble.Modus.Components.Constant;
 using Trimble.Modus.Components.Enums;
-using Trimble.Modus.Components.Helpers;
 using static System.Math;
 
 namespace Trimble.Modus.Components.Controls.Slider
@@ -57,9 +56,8 @@ namespace Trimble.Modus.Components.Controls.Slider
             {
                 leftPadding = 14;
             }
-            return new Label
+            var label= new Label
             {
-                TextColor = ResourcesDictionary.GetColor(ColorsConstants.Secondary),
                 FontSize = 8,
                 HorizontalTextAlignment = TextAlignment.Start,
                 LineBreakMode = LineBreakMode.NoWrap,
@@ -67,6 +65,9 @@ namespace Trimble.Modus.Components.Controls.Slider
                 Padding = new Thickness(0, 4, 0, 0),
                 HorizontalOptions = LayoutOptions.StartAndExpand,
             };
+
+            label.SetDynamicResource(Label.TextColorProperty, ColorsConstants.Secondary);
+            return label;
         }
 
         public static StackLayout CreateStepLabelContainer() =>
@@ -89,15 +90,17 @@ namespace Trimble.Modus.Components.Controls.Slider
             {
                 leftPadding = 14;
             }
-            return new BoxView
+            var boxView= new BoxView
             {
                 HorizontalOptions = LayoutOptions.CenterAndExpand,
                 VerticalOptions = LayoutOptions.FillAndExpand,
                 Margin = new Thickness(leftPadding, 0, 0, 0),
                 WidthRequest = 1,
-                HeightRequest = 4,
-                Color = ResourcesDictionary.GetColor(ColorsConstants.Secondary)
+                HeightRequest = 4
             };
+
+            boxView.SetDynamicResource(BoxView.ColorProperty, ColorsConstants.Secondary);
+            return boxView;
         }
     }
 }

--- a/Trimble.Modus.Components/Controls/TMSlider/TMRangeSlider.cs
+++ b/Trimble.Modus.Components/Controls/TMSlider/TMRangeSlider.cs
@@ -5,7 +5,6 @@ using Trimble.Modus.Components.Constant;
 using Trimble.Modus.Components.Controls;
 using Trimble.Modus.Components.Controls.Slider;
 using Trimble.Modus.Components.Enums;
-using Trimble.Modus.Components.Helpers;
 using static System.Math;
 
 namespace Trimble.Modus.Components
@@ -291,8 +290,8 @@ namespace Trimble.Modus.Components
 
             Track.StrokeThickness = 0;
             TrackHighlight.StrokeThickness = 0;
-            UpperValueLabel.TextColor = ResourcesDictionary.GetColor(ColorsConstants.DefaultTextColor);
-            LowerValueLabel.TextColor = ResourcesDictionary.GetColor(ColorsConstants.DefaultTextColor);
+            UpperValueLabel.SetDynamicResource(Label.TextColorProperty, ColorsConstants.DefaultTextColor);
+            LowerValueLabel.SetDynamicResource(Label.TextColorProperty, ColorsConstants.DefaultTextColor); 
 
             var trackSize = 8;
             _thumbSize = 24;

--- a/Trimble.Modus.Components/Controls/TMSlider/TMSlider.cs
+++ b/Trimble.Modus.Components/Controls/TMSlider/TMSlider.cs
@@ -5,7 +5,6 @@ using Trimble.Modus.Components.Constant;
 using Trimble.Modus.Components.Controls;
 using Trimble.Modus.Components.Controls.Slider;
 using Trimble.Modus.Components.Enums;
-using Trimble.Modus.Components.Helpers;
 using static System.Math;
 
 namespace Trimble.Modus.Components
@@ -230,7 +229,7 @@ namespace Trimble.Modus.Components
 
             Track.StrokeThickness = 0;
             TrackHighlight.StrokeThickness = 0;
-            ValueLabel.TextColor = ResourcesDictionary.GetColor(ColorsConstants.AlternateTextColor);
+            ValueLabel.SetDynamicResource(Label.TextColorProperty, ColorsConstants.AlternateTextColor);
             var trackSize = 8;
             _thumbSize = 24;
             var thumbStrokeThickness = 3;

--- a/Trimble.Modus.Components/Controls/TabBar/TMTabbedPage.cs
+++ b/Trimble.Modus.Components/Controls/TabBar/TMTabbedPage.cs
@@ -2,7 +2,6 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Trimble.Modus.Components.Constant;
-using Trimble.Modus.Components.Helpers;
 
 namespace Trimble.Modus.Components;
 
@@ -66,17 +65,16 @@ public partial class TMTabbedPage : ContentPage
 
         tabStripContainer = new Grid
         {
-            BackgroundColor = ResourcesDictionary.GetColor(ColorsConstants.Primary),
             HeightRequest = 70,
             VerticalOptions = LayoutOptions.Fill
         };
 
+        tabStripContainer.SetDynamicResource(BackgroundColorProperty, ColorsConstants.Primary);
         mainContainer = new Grid
         {
-            BackgroundColor = ResourcesDictionary.GetColor(ColorsConstants.Danger),
             RowSpacing = 0
         };
-
+        mainContainer.SetDynamicResource(BackgroundColorProperty, ColorsConstants.Danger);
         mainContainer.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
         mainContainer.RowDefinitions.Add(new RowDefinition { Height = 70 });
 
@@ -84,10 +82,8 @@ public partial class TMTabbedPage : ContentPage
         var isCurrentDevicePlatformIsWindows = DeviceInfo.Current.Platform == DevicePlatform.WinUI;
         if (isCurrentDevicePlatformIsWindows)
         {
-            contentViewContainer = new ContentView
-            {
-                BackgroundColor = ResourcesDictionary.GetColor(ColorsConstants.TertiaryLight)
-            };
+            contentViewContainer = new ContentView();
+            contentViewContainer.SetDynamicResource(BackgroundColorProperty, ColorsConstants.TertiaryLight);
             Grid.SetRow(contentViewContainer, 0);
             mainContainer.Children.Add(contentViewContainer);
         }
@@ -95,7 +91,6 @@ public partial class TMTabbedPage : ContentPage
         {
             contentContainer = new CarouselView
             {
-                BackgroundColor = ResourcesDictionary.GetColor(ColorsConstants.TertiaryLight),
                 ItemsSource = TabItems,
                 ItemTemplate = new DataTemplate(() =>
                 {
@@ -103,6 +98,7 @@ public partial class TMTabbedPage : ContentPage
                     contentView.SetBinding(ContentView.ContentProperty, "ContentView");
                     return contentView;
                 }),
+
                 // TODO: Disbaled Swipe and Scroll animation. While scrolling tabs updating wrong content.
                 IsSwipeEnabled = false,
                 IsScrollAnimated = false,
@@ -112,6 +108,7 @@ public partial class TMTabbedPage : ContentPage
 
             };
 
+            contentContainer.SetDynamicResource(BackgroundColorProperty, ColorsConstants.TertiaryLight);
             contentContainer.PropertyChanged += OnContentContainerPropertyChanged;
             // TODO: Disbaled Swipe and Scroll animation. While scrolling tabs updating wrong content.
             //contentContainer.Scrolled += OnContentContainerScrolled;
@@ -150,11 +147,11 @@ public partial class TMTabbedPage : ContentPage
         {
             if ((TabColor)newValue == TabColor.Primary)
             {
-                tabbedPage.tabStripContainer.BackgroundColor = ResourcesDictionary.GetColor(ColorsConstants.Primary);
+                tabbedPage.tabStripContainer.SetDynamicResource(BackgroundColorProperty, ColorsConstants.Primary);
             }
             else
             {
-                tabbedPage.tabStripContainer.BackgroundColor = ResourcesDictionary.GetColor(ColorsConstants.SecondaryDark);
+                tabbedPage.tabStripContainer.SetDynamicResource(BackgroundColorProperty, ColorsConstants.SecondaryDark);
             }
         }
     }

--- a/Trimble.Modus.Components/Controls/TabBar/TabViewItem.xaml.cs
+++ b/Trimble.Modus.Components/Controls/TabBar/TabViewItem.xaml.cs
@@ -1,7 +1,7 @@
-﻿using System.Windows.Input;
+﻿using CommunityToolkit.Maui.Behaviors;
+using System.Windows.Input;
 using Trimble.Modus.Components.Constant;
 using Trimble.Modus.Components.Helpers;
-using CommunityToolkit.Maui.Behaviors;
 
 namespace Trimble.Modus.Components;
 
@@ -139,7 +139,14 @@ public partial class TabViewItem : ContentView
         icon.Behaviors.Clear();
         icon.Behaviors.Add(new IconTintColorBehavior { TintColor = selectedColor });
 
-        selectedBorder.BackgroundColor = !IsSelected ? ResourcesDictionary.GetColor(ColorsConstants.Transparent) : ResourcesDictionary.GetColor(ColorsConstants.PrimaryLight);
+        if (IsSelected)
+        {
+            selectedBorder.SetDynamicResource(BackgroundColorProperty, ColorsConstants.Transparent);
+        }
+        else
+        {
+            selectedBorder.SetDynamicResource(BackgroundColorProperty, ColorsConstants.PrimaryLight);
+        }
     }
     private static void OnTabViewItemPropertyChanged(BindableObject bindable, object oldValue, object newValue)
     {

--- a/Trimble.Modus.Components/Helpers/ResourceDictionary.cs
+++ b/Trimble.Modus.Components/Helpers/ResourceDictionary.cs
@@ -4,6 +4,22 @@ public static class ResourcesDictionary
 {
     public static Color GetColor(string styleKey)
     {
-        return Application.Current.Resources[styleKey] as Color;
+        if (Application.Current.Resources.ContainsKey(styleKey))
+        {
+            return Application.Current.Resources[styleKey] as Color;
+        }
+        else
+        {
+            ResourceDictionary style = new Styles.LightThemeColors();
+            if (Application.Current.RequestedTheme == AppTheme.Dark)
+            {
+                style = new Styles.DarkThemeColors();
+            }
+            if (style.ContainsKey(styleKey))
+            {
+                return style[styleKey] as Color;
+            }
+        }
+        return Colors.Transparent;
     }
 }

--- a/Trimble.Modus.Components/Trimble.Modus.Components.csproj
+++ b/Trimble.Modus.Components/Trimble.Modus.Components.csproj
@@ -31,7 +31,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Trimble.Modus.Components</PackageId>
     <Title>Trimbel Modus</Title>
-    <Version>1.0.30-beta</Version>
+    <Version>1.0.38-beta</Version>
     <Authors>Trimble Inc</Authors>
     <Company>Trimble Inc</Company>
     <Product>Trimble.Modus.Components</Product>


### PR DESCRIPTION
Changes for Primary key not found exception. This is because the Windows launch event gets hit after the main page is initialized. If the main page has any modus components it's not working as expected