### PR TITLE
Modus Control Label LineBreakMode ="WordWrap" is not working #428

### DIFF
--- a/Trimble.Modus.Components/Controls/Label/ControlLabel.xaml
+++ b/Trimble.Modus.Components/Controls/Label/ControlLabel.xaml
@@ -16,7 +16,7 @@
   <Grid x:Name="view"
         BindingContext="{x:Reference controlLabelView}"
         ColumnSpacing="6"
-        ColumnDefinitions="auto,*"
+        ColumnDefinitions="*,auto"
         IsVisible="{Binding TitleText,Converter={StaticResource IsStringNotNullOrEmptyConverter}}">
     <Label x:Name="inputLabel"
            Padding="0,0,0,5"

--- a/Trimble.Modus.Components/Trimble.Modus.Components.csproj
+++ b/Trimble.Modus.Components/Trimble.Modus.Components.csproj
@@ -26,8 +26,8 @@
 
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Trimble.Modus.Components</PackageId>
-    <Title>Trimbel Modus</Title>
-    <Version>1.2.2.1</Version>
+    <Title>Trimble Modus</Title>
+    <Version>1.2.3.1</Version>
     <Authors>Trimble Inc</Authors>
     <Company>Trimble Inc</Company>
     <Product>Trimble.Modus.Components</Product>


### PR DESCRIPTION
We had set the "auto" for column width of label, Hence the line LineBreakMode ="WordWrap" is not working, then i have changed to column width as "*". It is working.