### PR TITLE
TMToast - Getting exception when click close button #450

### DIFF
--- a/Trimble.Modus.Components/Controls/Toast/TMToastContents.xaml.cs
+++ b/Trimble.Modus.Components/Controls/Toast/TMToastContents.xaml.cs
@@ -156,18 +156,17 @@ public partial class TMToastContents : PopupPage
 
     }
 
-    bool isPopupClosed = false;
     private void CloseButtonClicked(object sender, EventArgs e)
-    {        
-        PopupService.Instance.RemovePageAsync(this, true);
-        isPopupClosed = true;
+    {
+        if (PopupService.Instance.PopupStack.Contains(this))
+            PopupService.Instance.RemovePageAsync(this, true);
     }
     public void CloseAfterDelay()
     {
         Task.Run(async () =>
         {
             await Task.Delay(DELAYTIME);
-            if (!isPopupClosed)
+            if (PopupService.Instance.PopupStack.Contains(this))
                 await PopupService.Instance.RemovePageAsync(this, true);
         });
     }

--- a/Trimble.Modus.Components/Controls/Toast/TMToastContents.xaml.cs
+++ b/Trimble.Modus.Components/Controls/Toast/TMToastContents.xaml.cs
@@ -155,18 +155,20 @@ public partial class TMToastContents : PopupPage
         UpdateIconColor();
 
     }
+
+    bool isPopupClosed = false;
     private void CloseButtonClicked(object sender, EventArgs e)
-
-    {
+    {        
         PopupService.Instance.RemovePageAsync(this, true);
-
+        isPopupClosed = true;
     }
     public void CloseAfterDelay()
     {
         Task.Run(async () =>
         {
             await Task.Delay(DELAYTIME);
-            await PopupService.Instance.RemovePageAsync(this, true);
+            if (!isPopupClosed)
+                await PopupService.Instance.RemovePageAsync(this, true);
         });
     }
 

--- a/Trimble.Modus.Components/Trimble.Modus.Components.csproj
+++ b/Trimble.Modus.Components/Trimble.Modus.Components.csproj
@@ -27,7 +27,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Trimble.Modus.Components</PackageId>
     <Title>Trimble Modus</Title>
-    <Version>1.3.0.2</Version>
+    <Version>1.3.0.3</Version>
     <Authors>Trimble Inc</Authors>
     <Company>Trimble Inc</Company>
     <Product>Trimble.Modus.Components</Product>


### PR DESCRIPTION
In the TMToast control, we encountered an exception because the popup was being removed twice. Initially, the popup was removed when the close button was clicked, and then it was removed again after the delay time expired. This was the cause of the issue. It has now been fixed as part of [ticket #450](https://github.com/trimble-oss/modus-mobile-maui-components/issues/450).