### PR TITLE
Dropdown popup is not opening in .net 10 #457

### DIFF
--- a/Trimble.Modus.Components/Controls/DropDown/DropDownContents.xaml.cs
+++ b/Trimble.Modus.Components/Controls/DropDown/DropDownContents.xaml.cs
@@ -39,17 +39,18 @@ public partial class DropDownContents : PopupPage
     public Thickness Margin { get; set; }
     public IEnumerable ItemSource { get; set; }
     public double DesiredHeight { get; set; }
+    public double DesiredWidth { get; set; }
     public EventHandler<SelectedItemChangedEventArgs> SelectedEventHandler { get; set; }
     public int SelectedIndex { get; set; }
     public double YPosition { get; set; }
     public new double Height { get; set; }
-
+    public Action ChangeIndicatorWhenPopupRemove { get; set; }
     public void Build()
     {
         Animation = new RevealAnimation(DesiredHeight);
         border.Margin = Margin;
         border.HeightRequest = DesiredHeight;
-        border.WidthRequest = WidthRequest;
+        border.WidthRequest = DesiredWidth;
         listView.ItemsSource = ItemSource;
         if (SelectedIndex < 0)
         {
@@ -70,7 +71,11 @@ public partial class DropDownContents : PopupPage
 #endif
         }
     }
-
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        ChangeIndicatorWhenPopupRemove?.Invoke();
+    }
     private static void UpdateBackgroundColorOfCell(ListView listView)
     {
         if (listView.SelectedItem != null)

--- a/Trimble.Modus.Components/Controls/DropDown/TMDropDown.xaml.cs
+++ b/Trimble.Modus.Components/Controls/DropDown/TMDropDown.xaml.cs
@@ -244,10 +244,11 @@ public partial class TMDropDown : ContentView
                 SelectedItem = this.SelectedItem,
                 Margin = margin,
                 DesiredHeight = desiredHeight,
-                WidthRequest = innerBorder.Width,
+                DesiredWidth = innerBorder.Width,
                 SelectedEventHandler = OnSelected,
                 YPosition = loc.Y,
-                Height = height
+                Height = height,
+                ChangeIndicatorWhenPopupRemove = OnPopupRemoved
             };
             dropDownContents.Build();
             await Task.WhenAll(
@@ -260,7 +261,7 @@ public partial class TMDropDown : ContentView
         }
     }
 
-    private void OnPopupRemoved(object sender, EventArgs e)
+    private void OnPopupRemoved()
     {
         Close();
     }

--- a/Trimble.Modus.Components/Controls/DropDown/TMDropDown.xaml.cs
+++ b/Trimble.Modus.Components/Controls/DropDown/TMDropDown.xaml.cs
@@ -384,7 +384,12 @@ public partial class TMDropDown : ContentView
         SelectionChanged = null;
         SelectionChangedCommand = null;
         ItemsSource = null;
-        dropDownContents = null;
+        if (dropDownContents != null)
+        {
+            dropDownContents.ChangeIndicatorWhenPopupRemove = null;
+            dropDownContents = null;
+        }
         previousSelection = null;
+        
     }
 }

--- a/Trimble.Modus.Components/Controls/Popup/Animations/RevealAnimation.cs
+++ b/Trimble.Modus.Components/Controls/Popup/Animations/RevealAnimation.cs
@@ -19,7 +19,7 @@ public class RevealAnimation : BaseAnimation
         if (HasBackgroundAnimation)
         {
             _defaultOpacity = page.Opacity;
-            page.HeightRequest = 0;
+            //page.HeightRequest = 0;
         }
         else if (content != null)
         {

--- a/Trimble.Modus.Components/Trimble.Modus.Components.csproj
+++ b/Trimble.Modus.Components/Trimble.Modus.Components.csproj
@@ -27,7 +27,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Trimble.Modus.Components</PackageId>
     <Title>Trimble Modus</Title>
-    <Version>1.4.0.2</Version>
+    <Version>1.4.0.3</Version>
     <Authors>Trimble Inc</Authors>
     <Company>Trimble Inc</Company>
     <Product>Trimble.Modus.Components</Product>


### PR DESCRIPTION
We have upgraded groundworks app to .net 10, then dropdown popup is not opening when we click the dropdown. 
I have made simple changes on setting width request for the dropdown popup and removed the page height request on the Reveal animation class
Added event for changing the dropdown indicator when class the popup by clicking outside