### PR TITLE
459 text cutoff issue and hide issue on modal popup

### DIFF
--- a/Trimble.Modus.Components/Controls/Label/ControlLabel.xaml
+++ b/Trimble.Modus.Components/Controls/Label/ControlLabel.xaml
@@ -5,23 +5,25 @@
              xmlns:local="clr-namespace:Trimble.Modus.Components;assembly=Trimble.Modus.Components"
              x:Class="Trimble.Modus.Components.ControlLabel"
              x:Name="controlLabelView">
-  <Grid x:Name="view"
-        BindingContext="{x:Reference controlLabelView}"
-        ColumnSpacing="6"
-        ColumnDefinitions="auto,auto"
-        IsVisible="{Binding TitleText,Converter={StaticResource IsStringNotNullOrEmptyConverter}}">
+  <Grid x:Name="view" 
+  BindingContext="{x:Reference controlLabelView}"
+  ColumnSpacing="6"
+  ColumnDefinitions="*,Auto" HorizontalOptions="Start"
+  IsVisible="{Binding TitleText,Converter={StaticResource IsStringNotNullOrEmptyConverter}}">
     <Label x:Name="inputLabel"
-           Padding="0,0,0,5"
-           Grid.Column="0"
-           FontFamily="OpenSansSemibold"
-           Text="{Binding TitleText}"
-           VerticalOptions="Center"
-           LineBreakMode="WordWrap"
-           HorizontalOptions="Start" />
+       Padding="0,0,0,5"        
+       Grid.Column="0"
+       FontFamily="OpenSansSemibold"
+       Text="{Binding TitleText}"
+       VerticalOptions="Center"
+       LineBreakMode="WordWrap"           
+       HorizontalOptions="Start" />
     <Label Text="*"
-           Grid.Column="1"
-           IsVisible="{Binding IsRequired}"
-           FontFamily="OpenSansSemibold"
-           TextColor="{DynamicResource Danger}" />
+       Grid.Column="1"         
+       IsVisible="{Binding IsRequired}"
+       FontFamily="OpenSansSemibold"
+       HorizontalOptions="Start"
+       VerticalOptions="Center"
+       TextColor="{DynamicResource Danger}" />
   </Grid>
 </ContentView>

--- a/Trimble.Modus.Components/Controls/TMModal/TMModalContents.xaml.cs
+++ b/Trimble.Modus.Components/Controls/TMModal/TMModalContents.xaml.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Maui.Behaviors;
+using System;
 using Trimble.Modus.Components.Constant;
 using Trimble.Modus.Components.Enums;
 using Trimble.Modus.Components.Popup.Services;
@@ -227,7 +228,7 @@ internal partial class TMModalContents
         var inputControl = new TMInput();
 
         inputConfigurationHandler?.Invoke(inputControl);
-
+        inputControl.SetDynamicResource(TMInput.HeaderTextColorProperty, "TMModalInputHeaderTextColor");
         ModalBodyContainer.Add(inputControl);
     }
 

--- a/Trimble.Modus.Components/Styles/DarkThemeStyling.xaml
+++ b/Trimble.Modus.Components/Styles/DarkThemeStyling.xaml
@@ -498,6 +498,8 @@
                          Color="{StaticResource IconDark}" />
   <styles:ReferenceColor x:Key="InputDefaultHelperTextColor"
                       Color="{StaticResource DefaultTextColor}" />
+  <styles:ReferenceColor x:Key="TMModalInputHeaderTextColor"
+                       Color="{StaticResource DefaultTextColor}"/>
 
   <!--Primary-->
   <styles:ReferenceColor x:Key="InputPrimaryBorderColor"

--- a/Trimble.Modus.Components/Styles/LightThemeStyling.xaml
+++ b/Trimble.Modus.Components/Styles/LightThemeStyling.xaml
@@ -493,6 +493,10 @@
                          Color="{StaticResource IconLight}" />
   <styles:ReferenceColor x:Key="InputDefaultHelperTextColor"
                         Color="{StaticResource DefaultTextColor}" />
+  <styles:ReferenceColor x:Key="TMModalInputHeaderTextColor"
+                       Color="{StaticResource DefaultTextColor}"/>
+
+
 
   <!--Primary-->
   <styles:ReferenceColor x:Key="InputPrimaryBorderColor"

--- a/Trimble.Modus.Components/Trimble.Modus.Components.csproj
+++ b/Trimble.Modus.Components/Trimble.Modus.Components.csproj
@@ -27,7 +27,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Trimble.Modus.Components</PackageId>
     <Title>Trimble Modus</Title>
-    <Version>1.4.0.3</Version>
+    <Version>1.4.0.4</Version>
     <Authors>Trimble Inc</Authors>
     <Company>Trimble Inc</Company>
     <Product>Trimble.Modus.Components</Product>


### PR DESCRIPTION
As Part of this Pull Request,

-Resolved text wrapping in TMInput: Fixed an issue where long titles were truncated when using a fixed width.
- In the Epiroc Android app, global styles default to a black background with white text. This caused TMInput titles within TMModal to be invisible, as the modal uses a white background. Created a new style for HeaderText that defaults to the standard input text color. Added logic to override this color only when specifically defined by Epiroc branding; otherwise, it falls back to the improved default to ensure visibility across all themes.
