### PR TITLE
Fix #469: Update thumb pan behavior for TMSlider on Android

### DIFF
--- a/Trimble.Modus.Components/Controls/TMSlider/SliderCore.cs
+++ b/Trimble.Modus.Components/Controls/TMSlider/SliderCore.cs
@@ -429,8 +429,7 @@ namespace Trimble.Modus.Components.Controls
         /// <summary>
         /// Get the Pan shift value for thumb 
         /// </summary>
-        protected double GetPanShiftValue(View view) =>
-            DeviceInfo.Platform == DevicePlatform.Android ? view.TranslationX : _thumbPositionMap[view];
+        protected double GetPanShiftValue(View view) => _thumbPositionMap[view];
 
         /// <summary>
         /// Add gesture recognizer for thumb


### PR DESCRIPTION
Removed platform branch in SliderCore.GetPanShiftValue to fix non-linear thumb panning on Android