### PR TITLE
Windows application blocks background UI interactions while toast popup is displayed  

### DIFF
--- a/Trimble.Modus.Components/Controls/Toast/TMToast.cs
+++ b/Trimble.Modus.Components/Controls/Toast/TMToast.cs
@@ -13,7 +13,16 @@ namespace Trimble.Modus.Components
         private Action? action = null;
         public ToastTheme theme = ToastTheme.DefaultToast;
         public bool isDismissable = true;
-        public int dismissDelay = 5000;
+        private int _dismissDelay = 5000;
+        public int dismissDelay
+        {
+            get => _dismissDelay;
+            set
+            {
+                if (value > 0)                    
+                    _dismissDelay = value;
+            }
+        }
         #endregion
         public TMToast(string message, string actionButtonText = null, Action? action = null)
         {

--- a/Trimble.Modus.Components/Controls/Toast/TMToast.cs
+++ b/Trimble.Modus.Components/Controls/Toast/TMToast.cs
@@ -14,7 +14,7 @@ namespace Trimble.Modus.Components
         public ToastTheme theme = ToastTheme.DefaultToast;
         public bool isDismissable = true;
         private int _dismissDelay = 5000;
-        public int dismissDelay
+        public int DismissDelay
         {
             get => _dismissDelay;
             set

--- a/Trimble.Modus.Components/Controls/Toast/TMToast.cs
+++ b/Trimble.Modus.Components/Controls/Toast/TMToast.cs
@@ -13,6 +13,7 @@ namespace Trimble.Modus.Components
         private Action? action = null;
         public ToastTheme theme = ToastTheme.DefaultToast;
         public bool isDismissable = true;
+        public int dismissDelay = 5000;
         #endregion
         public TMToast(string message, string actionButtonText = null, Action? action = null)
         {
@@ -31,7 +32,7 @@ namespace Trimble.Modus.Components
             {
                 throw new ArgumentNullException("Message is required");
             }
-            PopupService.Instance.PresentAsync(new TMToastContents(message, actionButtonText, theme, action, isDismissable), false);
+            PopupService.Instance.PresentAsync(new TMToastContents(message, actionButtonText, theme, action, isDismissable, dismissDelay), false);
         }
         #endregion
     }

--- a/Trimble.Modus.Components/Controls/Toast/TMToast.cs
+++ b/Trimble.Modus.Components/Controls/Toast/TMToast.cs
@@ -41,7 +41,7 @@ namespace Trimble.Modus.Components
             {
                 throw new ArgumentNullException("Message is required");
             }
-            PopupService.Instance.PresentAsync(new TMToastContents(message, actionButtonText, theme, action, isDismissable, dismissDelay), false);
+            PopupService.Instance.PresentAsync(new TMToastContents(message, actionButtonText, theme, action, isDismissable, DismissDelay), false);
         }
         #endregion
     }

--- a/Trimble.Modus.Components/Controls/Toast/TMToastContents.xaml.cs
+++ b/Trimble.Modus.Components/Controls/Toast/TMToastContents.xaml.cs
@@ -11,7 +11,7 @@ public partial class TMToastContents : PopupPage
 {
     #region Private Properties
 
-    private const int DELAYTIME = 5000;
+    private readonly int _delayTime;
 
     #endregion
 
@@ -40,8 +40,9 @@ public partial class TMToastContents : PopupPage
         propertyChanged: OnRightIconTintColorChanged);
 
 
-    internal TMToastContents(string message, string actionButtonText, ToastTheme theme, Action action, bool isDismissable)
+    internal TMToastContents(string message, string actionButtonText, ToastTheme theme, Action action, bool isDismissable, int dismissDelay = 5000)
     {
+        _delayTime = dismissDelay;
         InitializeComponent();
         SetTheme(theme.ToString());
         SetDynamicResource(StyleProperty, theme.ToString());
@@ -165,7 +166,7 @@ public partial class TMToastContents : PopupPage
     {
         Task.Run(async () =>
         {
-            await Task.Delay(DELAYTIME);
+            await Task.Delay(_delayTime);
             if (PopupService.Instance.PopupStack.Contains(this))
                 await PopupService.Instance.RemovePageAsync(this, true);
         });

--- a/Trimble.Modus.Components/Platforms/Windows/Popup/Handler/PopupPageRenderer.cs
+++ b/Trimble.Modus.Components/Platforms/Windows/Popup/Handler/PopupPageRenderer.cs
@@ -65,10 +65,10 @@ internal class PopupPageRenderer : ContentPanel
     private void OnLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
         DeviceDisplay.Current.MainDisplayInfoChanged += OnDisplayInfoChanged;
-        if (CurrentElement != null && CurrentElement.BackgroundInputTransparent)
+        if (CurrentElement != null && CurrentElement.BackgroundInputTransparent && !CurrentElement.CloseWhenBackgroundIsClicked)
         {
             this.Background = null;
-        }
+        }        
         else
         {
             PointerPressed += OnBackgroundClick;

--- a/Trimble.Modus.Components/Platforms/Windows/Popup/Handler/PopupPageRenderer.cs
+++ b/Trimble.Modus.Components/Platforms/Windows/Popup/Handler/PopupPageRenderer.cs
@@ -67,7 +67,7 @@ internal class PopupPageRenderer : ContentPanel
         DeviceDisplay.Current.MainDisplayInfoChanged += OnDisplayInfoChanged;
         if (CurrentElement != null && CurrentElement.BackgroundInputTransparent && !CurrentElement.CloseWhenBackgroundIsClicked)
         {
-            this.Background = null;
+            Background = null;
         }        
         else
         {

--- a/Trimble.Modus.Components/Platforms/Windows/Popup/Handler/PopupPageRenderer.cs
+++ b/Trimble.Modus.Components/Platforms/Windows/Popup/Handler/PopupPageRenderer.cs
@@ -65,7 +65,14 @@ internal class PopupPageRenderer : ContentPanel
     private void OnLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
     {
         DeviceDisplay.Current.MainDisplayInfoChanged += OnDisplayInfoChanged;
-        PointerPressed += OnBackgroundClick;
+        if (CurrentElement != null && CurrentElement.BackgroundInputTransparent)
+        {
+            this.Background = null;
+        }
+        else
+        {
+            PointerPressed += OnBackgroundClick;
+        }
     }
 
     private void OnDisplayInfoChanged(object? sender, DisplayInfoChangedEventArgs e)

--- a/Trimble.Modus.Components/Trimble.Modus.Components.csproj
+++ b/Trimble.Modus.Components/Trimble.Modus.Components.csproj
@@ -27,7 +27,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>Trimble.Modus.Components</PackageId>
     <Title>Trimble Modus</Title>
-    <Version>1.4.0.5</Version>
+    <Version>1.4.0.6</Version>
     <Authors>Trimble Inc</Authors>
     <Company>Trimble Inc</Company>
     <Product>Trimble.Modus.Components</Product>


### PR DESCRIPTION
Added a `dismissDelay` property to `TMToast` for configurable toast dismissal timing. 
Updated `TMToastContents` to use a dynamic `_delayTime` instead of a hardcoded value. 
Adjusted `PopupPageRenderer` to handle background click events based on `BackgroundInputTransparent`. 